### PR TITLE
Compile 2022

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+HERE=`pwd`
+
+# rm (possibly conflicting) already installed openbabel
+sudo apt remove libopenbabel libopenbabel-dev openbabel
+
+# install open-babel-2.4.0 from sources, system-wide
+tar xzvf openbabel-openbabel-2-4-0.tar.gz
+cd openbabel-openbabel-2-4-0
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr ../
+NPROCS=`getconf _NPROCESSORS_ONLN`
+make -j $NPROCS
+sudo make install
+
+# compile pharao
+cd $HERE
+mkdir pharao-3.0.4
+cd pharao-3.0.4
+cmake ../
+make -j $NPROCS
+
+# inform about the freshly compiled exe
+ls -l pharao-3.0.4/pharao

--- a/build.sh
+++ b/build.sh
@@ -23,4 +23,4 @@ cmake ../
 make -j $NPROCS
 
 # inform about the freshly compiled exe
-ls -l pharao-3.0.4/pharao
+ls -l $PWD/pharao


### PR DESCRIPTION
to compile pharao as of today, using the last openbabel version < 3.0.0